### PR TITLE
fix incorrect aggregation SQL and added vehicleType.motorcycle

### DIFF
--- a/smbbackend/_constants.py
+++ b/smbbackend/_constants.py
@@ -18,11 +18,9 @@ class VehicleType(Enum):
     bike = 2
     bus = 3
     car = 4
-    scooter = 5
-    motorbike = 6
-    average_motorbike = 7
-    train = 8
-    unknown = 9
+    motorcycle = 5
+    train = 6
+    unknown = 7
 
 
 class Pollutant(Enum):
@@ -36,9 +34,7 @@ class Pollutant(Enum):
 AVERAGE_PASSENGER_COUNT = {
     VehicleType.foot: 1,
     VehicleType.bike: 1,
-    VehicleType.scooter: 1,
-    VehicleType.motorbike: 1,
-    VehicleType.average_motorbike: 1,
+    VehicleType.motorcycle: 1,
     VehicleType.bus: 40,
     VehicleType.car: 1.5,
     VehicleType.train: 50,
@@ -54,87 +50,54 @@ EMISSIONS = {
         "unit": "mg/km",
         VehicleType.car: 1.1,
         VehicleType.bus: 4.4,
-        VehicleType.scooter: 0.3,
-        VehicleType.motorbike: 0.6,
+        VehicleType.motorcycle: (0.3 + 0.6) / 2,  # avg scooter and motorbike
         VehicleType.train: 0,
     },
     Pollutant.nox: {
         "unit": "mg/km",
         VehicleType.car: 460,
         VehicleType.bus: 6441,
-        VehicleType.scooter: 158,
-        VehicleType.motorbike: 165,
+        VehicleType.motorcycle: (158 + 165) / 2,  # avg scooter and motorbike
         VehicleType.train: 0,
     },
     Pollutant.co: {
         "unit": "mg/km",
         VehicleType.car: 617,
         VehicleType.bus: 1451,
-        VehicleType.scooter: 5282,
-        VehicleType.motorbike: 6505,
+        VehicleType.motorcycle: (5282 + 6505) / 2,  # avg scooter and motorbike
         VehicleType.train: 0,
     },
     Pollutant.co2: {
         "unit": "g/km",
         VehicleType.car: 177,
         VehicleType.bus: 668,
-        VehicleType.scooter: 49,
-        VehicleType.motorbike: 100,
+        VehicleType.motorcycle: (49 + 100) / 2,  # avg scooter and motorbike
         VehicleType.train: 65,
     },
     Pollutant.pm10: {
         "unit": "mg/km",
         VehicleType.car: 46,
         VehicleType.bus: 273,
-        VehicleType.scooter: 96,
-        VehicleType.motorbike: 34,
+        VehicleType.motorcycle: (96 + 34) / 2,  # avg scooter and motorbike
         VehicleType.train: 0,
     },
 }
-EMISSIONS[Pollutant.so2][VehicleType.average_motorbike] = _get_average(
-    EMISSIONS[Pollutant.so2][VehicleType.scooter],
-    EMISSIONS[Pollutant.so2][VehicleType.motorbike]
-)
-EMISSIONS[Pollutant.nox][VehicleType.average_motorbike] = _get_average(
-    EMISSIONS[Pollutant.nox][VehicleType.scooter],
-    EMISSIONS[Pollutant.nox][VehicleType.motorbike]
-)
-EMISSIONS[Pollutant.co][VehicleType.average_motorbike] = _get_average(
-    EMISSIONS[Pollutant.co][VehicleType.scooter],
-    EMISSIONS[Pollutant.co][VehicleType.motorbike]
-)
-EMISSIONS[Pollutant.co2][VehicleType.average_motorbike] = _get_average(
-    EMISSIONS[Pollutant.co2][VehicleType.scooter],
-    EMISSIONS[Pollutant.co2][VehicleType.motorbike]
-)
-EMISSIONS[Pollutant.pm10][VehicleType.average_motorbike] = _get_average(
-    EMISSIONS[Pollutant.pm10][VehicleType.scooter],
-    EMISSIONS[Pollutant.pm10][VehicleType.motorbike]
-)
 
 FUEL_PRICE = {
     "unit": "eur/l",
     VehicleType.bus: 1.432,
     VehicleType.car: 1.417,
-    VehicleType.motorbike: 1.545,
-    VehicleType.scooter: 1.545,
+    VehicleType.motorcycle: 1.545,
     VehicleType.train: 0,
 }
-FUEL_PRICE[VehicleType.average_motorbike] = _get_average(
-    FUEL_PRICE[VehicleType.scooter], FUEL_PRICE[VehicleType.motorbike])
 
 FUEL_CONSUMPTION = {
     "unit": "km/l",
     VehicleType.bus: 3,
     VehicleType.car: 11.5,
-    VehicleType.motorbike: 20,
-    VehicleType.scooter: 30,
+    VehicleType.motorcycle: (20 + 30) / 2,  # avg scooter and motorbike
     VehicleType.train: 0,
 }
-FUEL_CONSUMPTION[VehicleType.average_motorbike] = _get_average(
-    FUEL_CONSUMPTION[VehicleType.scooter],
-    FUEL_CONSUMPTION[VehicleType.motorbike]
-)
 
 TIME_COST_PER_HOUR_EURO = 8
 
@@ -142,27 +105,17 @@ DEPRECIATION_COST = {
     "unit": "euro/km",
     VehicleType.bus: 0,
     VehicleType.car: 0.106,
-    VehicleType.motorbike: 0.111,
-    VehicleType.scooter: 0.089,
+    VehicleType.motorcycle: (0.111 + 0.089) / 2,  # avg scooter and motorbike
     VehicleType.train: 0,
 }
-DEPRECIATION_COST[VehicleType.average_motorbike] = _get_average(
-    DEPRECIATION_COST[VehicleType.scooter],
-    DEPRECIATION_COST[VehicleType.motorbike]
-)
 
 OPERATION_COST = {
     "unit": "euro/km",
     VehicleType.bus: 0,
     VehicleType.car: 0.072,
-    VehicleType.motorbike: 0.058,
-    VehicleType.scooter: 0.162,
+    VehicleType.motorcycle: (0.058 + 0.162) / 2,  # avg scooter and motorbike
     VehicleType.train: 0,
 }
-OPERATION_COST[VehicleType.average_motorbike] = _get_average(
-    OPERATION_COST[VehicleType.scooter],
-    OPERATION_COST[VehicleType.motorbike]
-)
 
 TOTAL_COST_OVERHEAD = {
     VehicleType.car: 0.2,
@@ -192,13 +145,13 @@ CALORY_CONSUMPTION = {
 HEALTH_BENEFIT_INDEX = {
     VehicleType.foot: {
         "applicable_age": (20, 74),
-        "relatve_risk": 0.883,
+        "relative_risk": 0.883,
         "threshold": (146, "hours/year"),
         "maximum_percentage": 0.3
     },
     VehicleType.bike: {
         "applicable_age": (20, 64),
-        "relatve_risk": 0.899,
+        "relative_risk": 0.899,
         "threshold": (87, "hours/year"),
         "maximum_percentage": 0.45
     },

--- a/smbbackend/ingesttracks.py
+++ b/smbbackend/ingesttracks.py
@@ -124,7 +124,7 @@ def insert_collected_points(track_id: int, track_data: List[PointData],
                             db_cursor):
     query = _get_query("insert-collectedpoint.sql")
     for pt in track_data:
-        vehicle_type = _get_vehicle_type(pt.vehicleMode)
+        vehicle_type = _get_vehicle_type(int(pt.vehicleMode))
         db_cursor.execute(
             query,
             {
@@ -209,7 +209,7 @@ def _get_query(filename) -> str:
     return query
 
 
-def _get_vehicle_type(raw_vehicle_type: str) -> VehicleType:
+def _get_vehicle_type(raw_vehicle_type: int) -> VehicleType:
     """Return the vehicle type as used in the portal DB
 
     The mapping between vehicle types is based on the structure of the java
@@ -219,17 +219,10 @@ def _get_vehicle_type(raw_vehicle_type: str) -> VehicleType:
         72b3a336f97c600fee9b63d63af46a955076f6e9/app/src/main/java/it/\
         geosolutions/savemybike/model/Vehicle.java#L14
 
-    >>> _get_vehicle_type("1")
-    'foot'
-    >>> _get_vehicle_type("2")
-    'bike'
-
     """
-    return {
-        "1": VehicleType.foot,
-        "2": VehicleType.bike,
-        "3": VehicleType.bus,
-        "4": VehicleType.car,
-        "5": VehicleType.average_motorbike,  # moped
-        "6": VehicleType.train,
-    }.get(raw_vehicle_type, VehicleType.unknown)
+
+    try:
+        vehicle_type = VehicleType(raw_vehicle_type)
+    except ValueError:
+        vehicle_type = VehicleType.unknown
+    return vehicle_type

--- a/smbbackend/sqlqueries/update-track-aggregated-costs.sql
+++ b/smbbackend/sqlqueries/update-track-aggregated-costs.sql
@@ -12,3 +12,4 @@ UPDATE tracks_track SET aggregated_costs = (
     GROUP BY s.track_id
   ) AS agg
 )
+WHERE id = %(track_id)s

--- a/smbbackend/sqlqueries/update-track-aggregated-emissions.sql
+++ b/smbbackend/sqlqueries/update-track-aggregated-emissions.sql
@@ -17,3 +17,4 @@ UPDATE tracks_track SET aggregated_emissions = (
     GROUP BY s.track_id
   ) AS agg
 )
+WHERE id = %(track_id)s

--- a/smbbackend/sqlqueries/update-track-aggregated-health.sql
+++ b/smbbackend/sqlqueries/update-track-aggregated-health.sql
@@ -8,3 +8,4 @@ UPDATE tracks_track SET aggregated_health = (
     GROUP BY s.track_id
   ) AS agg
 )
+WHERE id = %(track_id)s


### PR DESCRIPTION
This PR fixes two issues:

1. SQL for aggregating track calculations was missing the `WHERE` clause

2. A new vehicle type `motorcycle` has been introduced and replaces `scooter`, `motorbike` and `average_motorbike`

   This vehicle type represents a generic motor bike and its values are taken from an average of scooter and motorbike. There shall be another PR in the `smb-portal` project, with similarly-scoped changes to harmonize the DB read/write cycle