### PR TITLE
filter out points which fall outside a region of interest

### DIFF
--- a/smbbackend/sqlqueries/delete-external-points.sql
+++ b/smbbackend/sqlqueries/delete-external-points.sql
@@ -1,0 +1,37 @@
+-- Delete points that are disjoint with the region of interest
+--
+-- Since the `tracks.regionofinterest` table has geometries of MultiPolygon
+-- AND may contain multiple rows, we employ a trick:
+-- -  dump all features
+-- -  then collect them again
+--
+-- The result is a single MultiPolygon with the combined geometries of all
+-- rows.
+--
+-- We finally do the deletion as the result of all points which are disjoint
+-- (i.e. do not intersect) this combined ROI geometry
+--
+
+with dumped as (
+  select (st_dump(geom)).geom as geom
+  from tracks_regionofinterest
+)
+,
+flattened_roi AS (
+  select st_collect(geom) as geom
+  from dumped
+)
+,
+disposable AS (
+  SELECT distinct(cp.id) as id
+  FROM
+    tracks_collectedpoint AS cp,
+    flattened_roi
+  WHERE cp.track_id = %(track_id)s
+    AND NOT st_intersects(the_geom, flattened_roi.geom)
+)
+
+DELETE
+FROM tracks_collectedpoint as cp
+WHERE cp.id = ANY(SELECT d.id FROM disposable AS d)
+RETURNING cp.id

--- a/smbbackend/sqlqueries/delete-track.sql
+++ b/smbbackend/sqlqueries/delete-track.sql
@@ -1,0 +1,1 @@
+DELETE FROM tracks_track WHERE id = %(track_id)s

--- a/smbbackend/sqlqueries/select-count-track-points.sql
+++ b/smbbackend/sqlqueries/select-count-track-points.sql
@@ -1,0 +1,3 @@
+SELECT COUNT(1)
+FROM tracks_collectedpoint
+WHERE track_id = %(track_id)s


### PR DESCRIPTION
This PR modifies the track ingestion calculation in order to disregard any collected points which fall outside some [region of interest](https://github.com/geosolutions-it/smb-portal/pull/161).

The spatial filtering is implemented by using a combination of PostGIS functions, as per `smbbackend/sqlqueries/delete-external-points.sql`.

fixes #18 