### PR TITLE
fix negative pm10 and co savings

### DIFF
--- a/smbbackend/calculateindexes.py
+++ b/smbbackend/calculateindexes.py
@@ -12,8 +12,6 @@
 
 from collections import namedtuple
 import logging
-import os
-import pathlib
 
 from . import _constants
 from ._constants import VehicleType
@@ -142,6 +140,11 @@ def calculate_emissions(vehicle_type: VehicleType,
                 _constants.AVERAGE_PASSENGER_COUNT[VehicleType.car]
         )
         saved = reference - emitted if vehicle_type != VehicleType.car else 0
+        # We take car as a reference, but it is not always the most pollutant
+        # vehicle type. E.g. riding a motorcycle emmits more CO and PM10 than
+        # a car. For those cases, we set `saved` to zero in order to prevent
+        # showing negative savings.
+        saved = max(saved, 0)
         result.update({
             pollutant.name: emitted,
             "{}_saved".format(pollutant.name): saved


### PR DESCRIPTION
This PR fixes calculation of emissions so that saved emissions cannot be lower than zero.

Since we are using as a reference the emissions produced by a car in a similar segment in order to calculate the saved emissions, it would be possible to have negative savings. This would happen for example with the `PM10` pollutant and a `motorcycle` vehicle type. The motorcycl actually emits more PM10 by km than a car, hence the negative savings.