### PR TITLE
adapt to changed s3 upload structure

### DIFF
--- a/smbbackend/processor.py
+++ b/smbbackend/processor.py
@@ -321,8 +321,8 @@ def get_data_from_s3(bucket_name: str, object_key: str,
 
 
 def get_track_owner_uuid(object_key: str) -> str:
-    search_obj = re.search(r"cognito/smb/([\w-]{36})", object_key)
-    return search_obj.group(1)
+    search_obj = re.search(r"[\w-]{36}", object_key)
+    return search_obj.group()
 
 
 def get_track_owner_internal_id(keycloak_uuid: str, db_cursor):

--- a/zappa_settings.json
+++ b/zappa_settings.json
@@ -13,6 +13,15 @@
         }
       },
       {
+        "function": "smbbackend.awshandlers.aws_track_handler",
+        "event_source": {
+          "arn": "arn:aws:sns:us-west-2:227022658256:smb_backend_production",
+          "events": [
+            "sns:Publish"
+          ]
+        }
+      },
+      {
         "function": "smbbackend.awshandlers.update_competitions",
         "expression": "cron(0 1 * * ? *)"
       }


### PR DESCRIPTION
This PR changes the way in which the code determines uploaded track owner by adapting to the new S3 structure.

The other change, to `zappa_settings` is for enabling the correct handling of lambdas in both dev and production environments