### PR TITLE
tweak track validation with input from real data

### DIFF
--- a/smbbackend/awshandlers.py
+++ b/smbbackend/awshandlers.py
@@ -58,7 +58,7 @@ def aws_track_handler(event: dict, context):
     message = _extract_sns_message(event)
     message_type, message_arguments = _parse_message(message)
     logger.info("message_type: {}".format(message_type))
-    logger.info("message_arguments: {}".format(message_type))
+    logger.info("message_arguments: {}".format(message_arguments))
     if USE_SYNCHRONOUS_EXECUTION in ["true", "1", "yes"]:
         handler = compact_track_handler
     else:
@@ -200,7 +200,7 @@ def _get_db_connection():
     )
 
 
-def _parse_message(message):
+def _parse_message(message: dict):
     s3_info = message.get("Records", [{}])[0].get("s3")
     if s3_info:
         message_type = MessageType.s3_received_track

--- a/smbbackend/processor.py
+++ b/smbbackend/processor.py
@@ -42,11 +42,13 @@ DATA_PROCESSING_PARAMETERS = {
     },
     "segments_minute_threshold": 20,
     "segments_temporal_lower_bound": dt.datetime(2018, 1, 1, tzinfo=pytz.utc),
-    "segments_temporal_upper_bound": dt.datetime.now(pytz.utc),
+    "segments_temporal_upper_bound": (
+        dt.datetime.now(pytz.utc) + dt.timedelta(days=1)),
     "segments_small_threshold": 1,
     "points_position_threshold": 0.1,
+    "points_accuracy_threshold": 10,
     "segments_speed_thresholds": {  # (average_speed, max_speed), in m/s
-        VehicleType.foot: (1.95, 2.78),  # 7km/h , 10 km/h
+        VehicleType.foot: (2.78, 2.78),  # 10km/h , 10 km/h
         VehicleType.bike: (30, 30),  # 108 km/h, 108 km/h
         VehicleType.motorcycle: (38.89, 52.78),  # 140 km/h, 190 km/h
         VehicleType.car: (38.89, 52.78),  # 140 km/h, 190 km/h
@@ -94,21 +96,23 @@ class PointData(object):
     timestamp: dt.datetime = None
     vehicle_type: VehicleType = None
 
-    def __init__(self, latitude: float, longitude: float,
+    def __init__(self, latitude: float, longitude: float, accuracy: float,
                  timestamp: dt.datetime, vehicle_type: VehicleType,
                  session_id: int):
         self.timestamp = timestamp
         self.vehicle_type = vehicle_type
         self.session_id = session_id
+        self.accuracy = accuracy
         self.geometry = ogr.Geometry(ogr.wkbPoint)
         self.geometry.AddPoint(longitude, latitude)
 
     def __str__(self):
         return (
-            "Point(latitude={}, longitude={}, timestamp={}, session_id={}, "
+            "Point(latitude={}, longitude={}, accuracy={}, timestamp={}, session_id={}, "
             "vehicle_type={})".format(
                 self.latitude,
                 self.longitude,
+                self.accuracy,
                 self.timestamp.isoformat(),
                 self.session_id,
                 self.vehicle_type.name
@@ -124,6 +128,7 @@ class PointData(object):
         return cls(
             latitude=float(info[12]),
             longitude=float(info[13]),
+            accuracy=float(info[3]),
             timestamp=dt.datetime.fromtimestamp(
                 int(info[20]) / 1000).replace(tzinfo=pytz.utc),
             vehicle_type=VehicleType(int(info[21])),
@@ -265,6 +270,7 @@ def process_data(points: List[PointData], db_cursor,
     filtered_points = filter_point_data(
         points,
         coordinate_transformer,
+        accuracy_threshold=settings["points_accuracy_threshold"],
         position_threshold=settings["points_position_threshold"]
     )
     segments = generate_segments(
@@ -338,11 +344,14 @@ def get_track_owner_internal_id(keycloak_uuid: str, db_cursor):
 
 
 def filter_point_data(points: List["PointData"], coordinate_transformer,
+                      accuracy_threshold: float,
                       position_threshold: float) -> List["PointData"]:
     """Remove parsed points that have invalid data
 
     Track point collections must obey the following logic:
 
+    - point accuracy must be higher than or equal to the input
+      ``accuracy_threshold`` value;
     - timestamps are always ascending between consecutive points;
     - it is not necessary to keep consecutive points that are too close in
       space to each other
@@ -355,7 +364,9 @@ def filter_point_data(points: List["PointData"], coordinate_transformer,
 
     """
 
-    result = [points[0]]
+    result = []
+    if points[0].accuracy <= accuracy_threshold:
+        result.append(points[0])
     for p1_index in range(len(points) - 1):
         p1 = points[p1_index]
         p2 = points[p1_index+1]
@@ -365,6 +376,9 @@ def filter_point_data(points: List["PointData"], coordinate_transformer,
         elif position_delta < position_threshold:
             logger.debug(
                 "Removing consecutive point too close to the previous one")
+        elif p2.accuracy > accuracy_threshold:
+            logger.debug(
+                "Removing point with bad accuracy ({} m)".format(p2.accuracy))
         else:
             result.append(p2)
     return result
@@ -471,7 +485,10 @@ def filter_invalid_temporal_points(segments: SegmentData,
         ts = point.timestamp
         result = lower_bound <= ts <= upper_bound
         if not result:
-            logger.debug("Point is outside temporal bounds")
+            logger.debug(
+                "Point is outside temporal bounds {} <= {} <= {}".format(
+                    lower_bound, ts, upper_bound)
+            )
         return result
 
     return _reconcile_segments(segments, test_func=_check_temporal_bounds)


### PR DESCRIPTION
-  we now discard points with bad accuracy, using 10 m as a default  threshold
-  default temporal upper bound has been changed in order to include dates in the near future. This should accommodate small drifts in clock time between server and mobile apps and stop otherwise valid segments from getting rejected
-  adjusted average speed thresholds in order to cope with real data
-  segment-wide validation is only done for `foot` and `bike` vehicle types now