### PR TITLE
track details are now updated in the ingestion phase

### DIFF
--- a/smbbackend/calculateindexes.py
+++ b/smbbackend/calculateindexes.py
@@ -82,7 +82,6 @@ def update_track_aggregated_data(track_id, db_cursor):
         "update-track-aggregated-emissions.sql",
         "update-track-aggregated-costs.sql",
         "update-track-aggregated-health.sql",
-        "update-track-info.sql",
     ]
     for query_file in queries:
         db_cursor.execute(get_query(query_file), query_kwargs)

--- a/smbbackend/processor.py
+++ b/smbbackend/processor.py
@@ -171,6 +171,7 @@ def ingest_s3_data(s3_bucket_name: str, object_key: str,
     )
     track_id = save_track(
         session_id, segments, track_owner, validation_errors, db_cursor)
+    utils.update_track_info(track_id, db_cursor)
     return track_id, validation_errors
 
 

--- a/smbbackend/standalonehandlers.py
+++ b/smbbackend/standalonehandlers.py
@@ -94,6 +94,7 @@ def main():
                         continue
                     track_id = processor.save_track(
                         session_id, segments, args.owner_uuid, errors, cursor)
+                    utils.update_track_info(track_id, cursor)
                     track_info = utils.get_track_info(track_id, cursor)
                     if track_info.is_valid:
                         logger.info("Calculating indexes...")

--- a/smbbackend/utils.py
+++ b/smbbackend/utils.py
@@ -99,3 +99,9 @@ def get_track_info(track_id, db_cursor) -> TrackInfo:
     else:
         raise RuntimeError("Invalid track id: {!r}".format(track_id))
 
+
+def update_track_info(track_id, db_cursor):
+    db_cursor.execute(
+        get_query("update-track-info.sql"),
+        {"track_id": track_id}
+    )


### PR DESCRIPTION
Details like `start_date`, `end_date`, etc were previously only saved in the DB during the indexes calculation phase. This turned out to be problematic since invalid tracks do not reach that stage, but they might need some of this info (for example, for being able to show correctly sorted tracks in the API).

As such, this PR implements saving the track info sooner, during track ingestion.