### PR TITLE
modify badge-related SQL queries in order to filter out invalid tracks

### DIFF
--- a/smbbackend/sqlqueries/select-count-bike-rides.sql
+++ b/smbbackend/sqlqueries/select-count-bike-rides.sql
@@ -1,8 +1,10 @@
 SELECT
-  date_trunc('day', start_date),
-  count(date_part('day', start_date))
-FROM tracks_segment
-WHERE start_date >= %(start)s
-  AND start_date < %(end)s
-  AND vehicle_type = 'bike'
-GROUP BY date_trunc('day', start_date)
+  date_trunc('day', s.start_date),
+  count(date_part('day', s.start_date))
+FROM tracks_segment AS s
+  JOIN tracks_track AS t ON (s.track_id = t.id)
+WHERE s.start_date >= %(start)s
+  AND s.start_date < %(end)s
+  AND s.vehicle_type = 'bike'
+  AND t.is_valid = TRUE
+GROUP BY date_trunc('day', s.start_date)

--- a/smbbackend/sqlqueries/select-count-tracks-by-date-interval.sql
+++ b/smbbackend/sqlqueries/select-count-tracks-by-date-interval.sql
@@ -1,6 +1,6 @@
 SELECT date_trunc('day', created_at), COUNT(1)
 FROM tracks_track
-WHERE
-  created_at >= %(start_date)s and
-  created_at <= %(end_date)s
+WHERE is_valid = TRUE
+  AND created_at >= %(start_date)s
+  AND created_at <= %(end_date)s
 GROUP BY date_trunc('day', created_at)

--- a/smbbackend/sqlqueries/select-count-vehicle-rides.sql
+++ b/smbbackend/sqlqueries/select-count-vehicle-rides.sql
@@ -2,4 +2,5 @@ SELECT COUNT(1) AS num_rides
 FROM tracks_segment AS s
   JOIN tracks_track AS t ON (t.id = s.track_id)
 WHERE vehicle_type = ANY(%(vehicle_types)s)
+  AND t.is_valid = TRUE
   AND t.owner_id = %(user_id)s

--- a/smbbackend/sqlqueries/select-pollutant-sum-by-user.sql
+++ b/smbbackend/sqlqueries/select-pollutant-sum-by-user.sql
@@ -1,4 +1,5 @@
 SELECT
   SUM((aggregated_emissions->>%(pollutant)s)::float)
 FROM tracks_track
-WHERE owner_id = %(user_id)s
+WHERE is_valid = TRUE
+  AND owner_id = %(user_id)s

--- a/smbbackend/sqlqueries/select-sum-consumed-calories.sql
+++ b/smbbackend/sqlqueries/select-sum-consumed-calories.sql
@@ -1,3 +1,4 @@
 SELECT SUM((aggregated_health->>'calories_consumed')::float)
 FROM tracks_track
 WHERE owner_id = %(user_id)s
+  AND is_valid = TRUE

--- a/smbbackend/sqlqueries/select-total-distance-on-vehicle-types.sql
+++ b/smbbackend/sqlqueries/select-total-distance-on-vehicle-types.sql
@@ -1,6 +1,8 @@
 SELECT SUM(st_length(s.geom::geography))
 FROM tracks_segment AS s
   JOIN bossoidc_keycloak AS k ON (s.user_uuid = k."UID")
+  JOIN tracks_track AS t ON (s.track_id = t.id)
 WHERE vehicle_type LIKE ANY(%(vehicle_types)s)
   AND k.user_id = %(user_id)s
+  AND t.is_valid = TRUE
 


### PR DESCRIPTION
This PR fixes a bug whereby badge awarding calculations were also using invalid tracks. They are now filtered out in the relevant SQL queries. 