### PR TITLE
disable track validation

### DIFF
--- a/smbbackend/processor.py
+++ b/smbbackend/processor.py
@@ -161,6 +161,12 @@ def ingest_s3_data(s3_bucket_name: str, object_key: str, owner_uuid: str,
         raise_on_invalid_data=False,
         **DATA_PROCESSING_PARAMETERS
     )
+
+    # Reset validation_errors to an empty list in order to effectively
+    # disable validation - This is a temporary measure
+    # TODO: re-enable validation results
+    validation_errors = []
+
     track_id = save_track(
         session_id, segments, owner_uuid, validation_errors, db_cursor)
     utils.update_track_info(track_id, db_cursor)


### PR DESCRIPTION
This PR disables track validation. Filtering of points and the actual validation code is still executed, but any validation errors are discarded.

This is a temporary measure while we make the validation more robust to real GPS data