### PR TITLE
Add outlier detection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
             "set-lambda-env=smbbackend.awsutils:main_set_lambda_env",
             "convert-spatialite=smbbackend.convertspatialfiles:main",
             "ingest-tracks=smbbackend.standalonehandlers:main",
+            "process-tracks-locally=smbbackend.ingestiontester:main"
         ]
     }
 )

--- a/smbbackend/awshandlers.py
+++ b/smbbackend/awshandlers.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 from typing import List
+from typing import Tuple
 
 from pyfcm import FCMNotification
 
@@ -50,6 +51,7 @@ def update_competitions(notify_completion=True):
         _send_notification(MessageType.competitions_have_been_updated)
 
 
+# FIXME - send notification after the db_connection `with` block has ended
 def aws_track_handler(event: dict, context):
     """Handler for lambda invocations
 
@@ -80,13 +82,12 @@ def compact_track_handler(message_type:MessageType, message_arguments: dict,
     if message_type == MessageType.s3_received_track:
         bucket_name, object_key, owner_uuid = get_new_track_info(
             db_cursor, notify_completion=notify, **message_arguments)
-        track_id, validation_errors = ingest_track(
+        track_id, is_valid = ingest_track(
             db_cursor, bucket_name, object_key, owner_uuid,
             notify_completion=notify
         )
-        logger.debug("track_id: {}".format(track_id))
-        logger.debug("validation_errors: {}".format(validation_errors))
-        if len(validation_errors) == 0:
+        logger.debug(f"track_id: {track_id} - is_valid: {is_valid}")
+        if is_valid:
             calculate_indexes(db_cursor, track_id, owner_uuid,
                               notify_completion=notify)
             update_badges(db_cursor, track_id, owner_uuid,
@@ -148,21 +149,24 @@ def get_new_track_info(db_cursor, bucket_name, object_key, **kwargs):
 
 
 def ingest_track(db_cursor, bucket_name, object_key, owner_uuid,
-                 notify_completion=True, **kwargs):
+                 notify_completion=True, **kwargs) -> Tuple[int, bool]:
     try:
-        track_id, session_id, validation_errors = processor.ingest_s3_data(
+        segments_data, track_id, session_id = processor.ingest_s3_data(
             s3_bucket_name=bucket_name,
             object_key=object_key,
             owner_uuid=owner_uuid,
             db_cursor=db_cursor
         )
+        validation_errors = [s[2] for s in segments_data]
         flattened_errors = _flatten_validation_errors(validation_errors)
+        is_valid = all([len(s) == 0 for s in validation_errors])
     except NonRecoverableError as exc:
         logger.exception("Could not perform track ingestion")
         track_id = None
         session_id = None
-        validation_errors = [{"message": exc.args[0]}]
-        flattened_errors = validation_errors[0]["message"]
+        validation_errors = [[{"message": exc.args[0]}]]
+        is_valid = False
+        flattened_errors = validation_errors[0][0]["message"]
     if notify_completion:
         _send_notification(
             MessageType.track_validated,
@@ -170,7 +174,7 @@ def ingest_track(db_cursor, bucket_name, object_key, owner_uuid,
                 "user_uuid": owner_uuid,
                 "track_id": track_id,
                 "session_id": session_id,
-                "is_valid": True if len(validation_errors) == 0 else False,
+                "is_valid": is_valid,
                 "validation_errors": flattened_errors
             },
             use_fcm=True,
@@ -178,7 +182,7 @@ def ingest_track(db_cursor, bucket_name, object_key, owner_uuid,
                 owner_uuid: get_user_active_devices(db_cursor, owner_uuid)
             }
         )
-    return track_id, validation_errors
+    return track_id, is_valid
 
 
 def calculate_indexes(db_cursor, track_id, owner_uuid,
@@ -292,14 +296,15 @@ def get_user_active_devices(db_cursor, user_uuid):
     return [row[0] for row in db_cursor.fetchall()]
 
 
-def _flatten_validation_errors(errors: List[dict]):
+def _flatten_validation_errors(errors: List[List[dict]]):
     flattened_errors = ""
-    for error in errors:
-        flattened_error = "{} ({}: {} - {})".format(
-            error["message"], error["variable"], error["value"],
-            error["vehicle_type"]
-        )
-        flattened_errors = ",".join((flattened_errors, flattened_error))
+    for segment_errors in errors:
+        for error in segment_errors:
+            flattened_error = "{} ({}: {} - {})".format(
+                error["message"], error["variable"], error["value"],
+                error["vehicle_type"]
+            )
+            flattened_errors = ",".join((flattened_errors, flattened_error))
     return flattened_errors
 
 

--- a/smbbackend/awshandlers.py
+++ b/smbbackend/awshandlers.py
@@ -157,15 +157,15 @@ def ingest_track(db_cursor, bucket_name, object_key, owner_uuid,
             owner_uuid=owner_uuid,
             db_cursor=db_cursor
         )
+        is_valid = processor.is_track_valid(segments_data)
         validation_errors = [s[2] for s in segments_data]
         flattened_errors = _flatten_validation_errors(validation_errors)
-        is_valid = all([len(s) == 0 for s in validation_errors])
     except NonRecoverableError as exc:
         logger.exception("Could not perform track ingestion")
         track_id = None
         session_id = None
-        validation_errors = [[{"message": exc.args[0]}]]
         is_valid = False
+        validation_errors = [[{"message": exc.args[0]}]]
         flattened_errors = validation_errors[0][0]["message"]
     if notify_completion:
         _send_notification(

--- a/smbbackend/ingestiontester.py
+++ b/smbbackend/ingestiontester.py
@@ -1,0 +1,266 @@
+#########################################################################
+#
+# Copyright 2018, GeoSolutions Sas.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#########################################################################
+
+import argparse
+import concurrent.futures
+from fnmatch import fnmatch
+import io
+import logging
+import os
+import pathlib
+import zipfile
+
+import boto3
+import dateutil.parser
+import pytz
+
+from . import processor
+from . import utils
+
+logger = logging.getLogger(__name__)
+
+
+processor.ENABLE_TRACK_VALIDATION = True
+
+
+def main():
+    parser = _get_parser()
+    args = parser.parse_args()
+    _setup_logging(logging.DEBUG if args.verbose else logging.INFO)
+    download_to = pathlib.Path(args.target_directory).expanduser().resolve()
+    download_to.mkdir(parents=True, exist_ok=True)
+    if not args.no_download:
+        s3 = boto3.resource("s3")
+        bucket = s3.Bucket(args.bucket_name)
+        logger.info("Downloading files from S3...")
+        download_new_files(
+            bucket,
+            download_to,
+            args.download_workers,
+            args.exclude_pattern,
+            args.modified_threshold
+        )
+    logger.info("Validating files...")
+    total_files, files_with_errors = process_files(
+        download_to,
+        args.pattern,
+        db_parameters={
+            "host": args.db_host,
+            "port": args.db_port,
+            "db_name": args.db_name,
+            "user": args.db_user,
+            "password": args.db_password,
+        }
+    )
+    logger.info(
+        f"Files processed: {total_files} - with errors: {files_with_errors}")
+    logger.info("Done!")
+
+
+def process_files(base_dir: pathlib.Path, item_pattern, db_parameters):
+    processing_futures = {}
+    with concurrent.futures.ProcessPoolExecutor() as executor:
+        total_files = 0
+        files_with_errors = 0
+        # for index, item in enumerate(base_dir.iterdir()):
+        #     if index > 2:
+        #         break
+        for item in base_dir.iterdir():
+            pattern_passes = item_pattern is None or fnmatch(
+                item.name, item_pattern)
+            if item.is_file() and pattern_passes:
+                total_files += 1
+                future = executor.submit(process_file, item, db_parameters)
+                processing_futures[future] = item
+        for future in concurrent.futures.as_completed(processing_futures):
+            file_path = str(processing_futures[future])
+            try:
+                validation_errors = future.result()
+                is_valid = all([len(s) == 0 for s in validation_errors])
+            except Exception:
+                logger.exception(
+                    msg=f"Could not process file {str(file_path)}")
+                files_with_errors += 1
+            else:
+                logger.info(
+                    f"path: {str(file_path)} errors: {validation_errors}")
+                if not is_valid:
+                    files_with_errors += 1
+    return total_files, files_with_errors
+
+
+
+def process_file(path: pathlib.Path, db_parameters):
+    logger.info(f"Processing file {str(path)}...")
+    with path.open() as fh:
+        raw_data = fh.read()
+    points = processor.parse_point_raw_data(raw_data)
+    db_connection = utils.get_db_connection(
+        host=db_parameters["host"],
+        port=db_parameters["port"],
+        dbname=db_parameters["db_name"],
+        user=db_parameters["user"],
+        password=db_parameters["password"],
+    )
+    cursor = db_connection.cursor()
+    segments_data = processor.process_data(
+        points,
+        cursor,
+        raise_on_invalid_data=False,
+        **processor.DATA_PROCESSING_PARAMETERS
+    )
+    for segment_data in segments_data:
+        logger.debug(f"{segment_data[1].geometry.ExportToWkt()}")
+    db_connection.close()
+    validation_errors = [s[2] for s in segments_data]
+    return validation_errors
+
+
+def download_new_files(bucket, download_to, max_workers, exclude: str=None,
+                       modified_since=None):
+    download_futures = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers) as executor:
+        for obj_summary in bucket.objects.all():
+            modified = obj_summary.last_modified
+            local_path = get_local_path(obj_summary.key, download_to)
+            if exclude is not None and fnmatch(obj_summary.key, exclude):
+                logger.debug(f"Ignoring object {obj_summary.key!r}...")
+                continue
+            elif modified_since is not None and modified < modified_since:
+                logger.debug(f"Ignoring object {obj_summary.key!r}...")
+                continue
+            elif local_path.exists():
+                logger.debug(f"Object {obj_summary.key!r} is already present "
+                             f"locally, ignoring...")
+                continue
+            download_future = executor.submit(
+                get_session_data,
+                bucket.name,
+                obj_summary.key,
+                local_path
+            )
+            download_futures[download_future] = obj_summary.key
+        for future in concurrent.futures.as_completed(download_futures):
+            key = download_futures[future]
+            try:
+                future.result()
+            except Exception:
+                logger.exception(msg="Couldn't download {}".format(key))
+
+
+def get_local_path(object_key: str, base_dir: pathlib.Path):
+    local_name = object_key.replace("/", "__").rpartition(".")[0]
+    return base_dir / f"{local_name}.csv"
+
+
+def get_session_data(bucket_name, object_key: str, target_path: pathlib.Path,
+                     use_boto_internal_threads=False):
+    logger.info(f"Downloading and extracting {object_key!r} to "
+                f"{str(target_path)!r}...")
+    # boto3 docs recommend creating new resources for each thread
+    # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/
+    #     resources.html#multithreading-multiprocessing
+    s3 = boto3.resource("s3")
+    bucket = s3.Bucket(bucket_name)
+    config = boto3.s3.transfer.TransferConfig(
+        use_threads=use_boto_internal_threads)
+    input_buffer = io.BytesIO()
+    bucket.download_fileobj(
+        Key=object_key,
+        Fileobj=input_buffer,
+        Config=config
+    )
+    with zipfile.ZipFile(input_buffer) as zip_handler:
+        for member_name in zip_handler.namelist():
+            with target_path.open("wb") as fh:
+                fh.write(zip_handler.read(member_name))
+
+
+def _get_parser():
+
+
+    def _get_modified_threshold(str_value):
+        return dateutil.parser.parse(str_value).replace(tzinfo=pytz.utc)
+
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "target_directory",
+        help="Base directory where files will be downloaded to. It will be "
+             "created if needed",
+    )
+    parser.add_argument(
+        "-b",
+        "--bucket-name",
+        help="Name of the S3 bucket to use. Defaults to the value of the "
+             "`S3_BUCKET` environment variable (currently '%(default)s'), if "
+             "any",
+    )
+    parser.add_argument(
+        "-x",
+        "--no-download",
+        help="Do not download any new data, use only what is already "
+             "available locally",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-m",
+        "--modified-threshold",
+        help="Earlier date that should be considered. All objects older than "
+             "this will be ignored. This should be a string parseable with "
+             "`dateutil.parser` and is expected to be in UTC time.",
+        type=_get_modified_threshold
+    )
+    parser.add_argument(
+        "-w",
+        "--download-workers",
+        default=8,
+        type=int,
+        help="Maximum concurrent download threads",
+    )
+    parser.add_argument(
+        "-e",
+        "--exclude-pattern",
+        help="An fnmatch pattern that is matched against existing object keys "
+             "to filter out objects that should not be downloaded"
+    )
+    parser.add_argument(
+        "-p",
+        "--pattern",
+        help="An fnmatch pattern that is matched against existing local "
+             "files and used to determine which files get processed"
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true"
+    )
+    parser.add_argument("--db-host")
+    parser.add_argument("--db-port", type=int)
+    parser.add_argument("--db-name")
+    parser.add_argument("--db-user")
+    parser.add_argument("--db-password")
+    parser.set_defaults(
+        bucket_name=os.getenv("S3_BUCKET"),
+        db_host=os.getenv("DB_HOST", "localhost"),
+        db_port=int(os.getenv("DB_PORT", "5432")),
+        db_name=os.getenv("DB_NAME"),
+        db_user=os.getenv("DB_USER"),
+        db_password=os.getenv("DB_PASSWORD"),
+    )
+    return parser
+
+
+def _setup_logging(level):
+    logging.basicConfig(level=level)
+    to_disable = [
+        "botocore",
+    ]
+    for log_name in to_disable:
+        logging.getLogger(log_name).propagate = False


### PR DESCRIPTION
This PR refactors the track ingestion and validation code with some significant changes:

- Track **validation is now re-enabled**

-  Removal of unreliable GPS data is done based on a simple outlier removal procedure. Points are analyzed pairwise, taking the average speed of each 2-point segment. The average and stddev of all speeds is taken. A speed threshold is set based on a certain deviation from the average (e.g. `average + 2 *stddev `). This speed threshold is dependent on vehicle type, being lower for `foot`. Points that participate in segments that are above the threshold get filtered out;

-  Bad accuracy filter has been raised to a more generous value, meaning that most points are now kept.

-  Maximum distance between consecutive points before generating a new segment has been adjusted in order to be consistent with speed limits

-  Points that are reported by the user's device as having `speed=None` are not removed anymore

- Handling of validation errors has been refactored so as to allow reporting all existing errors. The previous implementation was based on raising an exception as soon as a validation error occurred. We now collect all errors and return them explicitly, without raising.

Also, the `process-tracks-locally` console script has been introduced in order to ease testing real data