### PR TITLE
add more robust intersection check

### DIFF
--- a/smbbackend/awshandlers.py
+++ b/smbbackend/awshandlers.py
@@ -301,7 +301,7 @@ def _flatten_validation_errors(errors: List[List[dict]]):
     for segment_errors in errors:
         for error in segment_errors:
             flattened_error = "{} ({}: {} - {})".format(
-                error["message"], error["variable"], error["value"],
+                error["msg"], error["variable"], error["value"],
                 error["vehicle_type"]
             )
             flattened_errors = ",".join((flattened_errors, flattened_error))

--- a/smbbackend/ingestiontester.py
+++ b/smbbackend/ingestiontester.py
@@ -69,9 +69,6 @@ def process_files(base_dir: pathlib.Path, item_pattern, db_parameters):
     with concurrent.futures.ProcessPoolExecutor() as executor:
         total_files = 0
         files_with_errors = 0
-        # for index, item in enumerate(base_dir.iterdir()):
-        #     if index > 2:
-        #         break
         for item in base_dir.iterdir():
             pattern_passes = item_pattern is None or fnmatch(
                 item.name, item_pattern)


### PR DESCRIPTION
This PR adds some tweaks to track ingestion, most notably the `point_intersects_roi()` which implements a new way to check if a point intersects with the region of interest.

The motivation for this was the fact that ogr was giving incorrect intersection results for our multipolygon region of interest when using the whole multipart geom for doing the check. The proposed implementation iterates over each geometry of the multipart and does the check with it. Results seem consistent now.