### PR TITLE
add notifications for individual prize winners

### DIFF
--- a/smbbackend/sqlqueries/select-prize-name.sql
+++ b/smbbackend/sqlqueries/select-prize-name.sql
@@ -1,0 +1,6 @@
+SELECT
+  p.name
+FROM prizes_competitionprize AS cp
+  JOIN prizes_prize AS p ON (p.id = cp.prize_id)
+where competition_id = %(competition_id)s
+  and user_rank = %(user_rank)s


### PR DESCRIPTION
This PR adds FCM notifications for individual prize winners.
Each winner is sent a notification (to all of its active devices) for each prize that it has won. The notification payload just features the prize's name 