### PR TITLE
increase lambda timeout to 60s

### DIFF
--- a/smbbackend/processor.py
+++ b/smbbackend/processor.py
@@ -391,6 +391,7 @@ def filter_point_data(points: List["PointData"], coordinate_transformer,
     return result
 
 
+# TODO: This function runs very slowly. Find a faster implementation
 def remove_spatially_similar_points(points: List[PointData], threshold:float,
                                     coordinate_transformer) -> List[PointData]:
     result = []

--- a/smbbackend/utils.py
+++ b/smbbackend/utils.py
@@ -60,7 +60,6 @@ class ValidationError(Enum):
     segment_duration_too_long = 3
 
 
-
 def get_db_connection(dbname, user, password, host="localhost", port="5432"):
     return psycopg2.connect(
         host=host,

--- a/zappa_settings.json
+++ b/zappa_settings.json
@@ -32,6 +32,7 @@
       "pytest*",
       "tests*"
     ],
+    "timeout_seconds": 60,
     "keep_warm": false,
     "lambda_description": "backend calculations for save-my-bike",
     "manage_roles": false,


### PR DESCRIPTION
This PR increases lambda execution timeout from 30 s to 60 s.

This is a (temporary) fix to account for the increase in total processing time that was verified after the addition of the `processor.remove_spatially_similar_points()` function. This is causing larger uploaded tracks' ingestion to fail on AWS lambdas due to hitting the 30s timeout.

Also included in this PR are some minor changes to the `ingestiontester` module, which is used to verify execution times locally.