### PR TITLE
optimize geometry calculations

### DIFF
--- a/zappa_settings.json
+++ b/zappa_settings.json
@@ -32,7 +32,7 @@
       "pytest*",
       "tests*"
     ],
-    "timeout_seconds": 60,
+    "timeout_seconds": 300,
     "keep_warm": false,
     "lambda_description": "backend calculations for save-my-bike",
     "manage_roles": false,


### PR DESCRIPTION
This PR introduces some optimizations to the calculations that involve dealing with point and line geometries. Two major changes are proposed:

-  Points have their projected coordinates pre-computed. The `PointData` class now keeps instance attributes with the reprojected geometry and x and y values. These are used when needed, instead of reprojecting on-the-fly (which was the previous implementation). The same logic is also used for line segments, represented as `SegmentInfo` instances. These gain a new `projected_geometry` attribute, which is used when needed.
-  Only the 10 temporally closest points are evaluated when checking for duplicate positions. This assumes that points closer to each other are more likely to have faulty data (where the position is not being reported correctly) than points further apart 

Another noteworthy change is the bumping of AWS lambda timeout value to 5 minutes.