### PR TITLE
refactor sql queries and code in order to match updated db schema of competitions

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
 --requirement production.txt
 
 pytest==3.8.0
+pytest-raises==0.10

--- a/smbbackend/awshandlers.py
+++ b/smbbackend/awshandlers.py
@@ -153,12 +153,10 @@ def get_new_track_info(db_cursor, bucket_name, object_key, **kwargs):
 def ingest_track(db_cursor, bucket_name, object_key, owner_uuid,
                  notify_completion=True, **kwargs) -> Tuple[int, bool]:
     try:
-        segments_data, track_id, session_id = processor.ingest_s3_data(
-            s3_bucket_name=bucket_name,
-            object_key=object_key,
-            owner_uuid=owner_uuid,
-            db_cursor=db_cursor
-        )
+
+        raw_data = processor.get_data_from_s3(bucket_name, object_key)
+        segments_data, track_id, session_id = processor.ingest_data(
+            raw_data, owner_uuid, db_cursor)
         is_valid = processor.is_track_valid(segments_data)
         validation_errors = [s[2] for s in segments_data]
         flattened_errors = _flatten_validation_errors(validation_errors)

--- a/smbbackend/processor.py
+++ b/smbbackend/processor.py
@@ -247,11 +247,12 @@ class PointData(object):
         return self.projected_geometry.Distance(other_point.projected_geometry)
 
 
-def ingest_s3_data(s3_bucket_name: str, object_key: str, owner_uuid: str,
-                   db_cursor) -> Tuple[FullSegmentData, int, int]:
+def ingest_data(
+        raw_data: str,
+        owner_uuid: str,
+        db_cursor
+):
     """Ingest track data into smb database"""
-    logger.debug("Retrieving data from S3 bucket...")
-    raw_data = get_data_from_s3(s3_bucket_name, object_key)
     points = parse_point_raw_data(raw_data)
     session_id = get_session_id(points)
     segments_data = process_data(

--- a/smbbackend/sqlqueries/insert-competition-winner.sql
+++ b/smbbackend/sqlqueries/insert-competition-winner.sql
@@ -1,10 +1,8 @@
 -- insert a new winner for the specified competition
 INSERT INTO prizes_winner (
-  competition_id,
-  user_id,
+  participant_id,
   rank
 ) VALUES (
-  %(competition_id)s,
-  %(user_id)s,
+  %(participant_id)s,
   %(rank)s
 )

--- a/smbbackend/sqlqueries/select-competitionparticipant.sql
+++ b/smbbackend/sqlqueries/select-competitionparticipant.sql
@@ -1,0 +1,4 @@
+SELECT id
+FROM prizes_competitionparticipant
+WHERE competition_id = %(competition_id)s
+    AND user_id = %(user_id)s

--- a/smbbackend/sqlqueries/select-current-competitions-info.sql
+++ b/smbbackend/sqlqueries/select-current-competitions-info.sql
@@ -8,6 +8,7 @@ SELECT
   c.end_date,
   c.age_groups
 FROM prizes_competition AS c
-  LEFT OUTER JOIN prizes_winner AS w ON (c.id = w.competition_id)
+  JOIN prizes_competitionparticipant AS cp ON (c.id = cp.competition_id)
+  LEFT OUTER JOIN prizes_winner AS w ON (cp.id = w.participant_id)
 WHERE c.start_date <= %(relevant_date)s
-  AND w.user_id IS null
+  AND w.participant_id IS null

--- a/smbbackend/sqlqueries/select-pollutant-savings-leaderboard.sql
+++ b/smbbackend/sqlqueries/select-pollutant-savings-leaderboard.sql
@@ -1,19 +1,17 @@
 SELECT
   ROW_NUMBER() OVER (ORDER BY SUM(e.{pollutant_name})) AS points,
-  u.id,
-  p.age,
+  cp.user_id AS user_id,
   SUM(e.{pollutant_name})
 FROM tracks_segment AS s
   JOIN tracks_emission AS e ON (s.id = e.segment_id)
   JOIN tracks_track AS t ON (t.id = s.track_id)
-  JOIN profiles_smbuser AS u ON (u.id = t.owner_id)
-  JOIN profiles_enduserprofile AS p ON (p.user_id = u.id)
+  JOIN prizes_competitionparticipant AS cp ON (t.owner_id = cp.user_id)
+  JOIN prizes_competition AS c ON (c.id = cp.competition_id)
 WHERE s.start_date >= %(start_date)s
   AND s.end_date <= %(end_date)s
-  AND p.age = ANY(%(age_groups)s)
   AND t.is_valid = true
-GROUP BY
-  u.id,
-  p.age
+  AND cp.registration_status = 'approved'
+  AND c.id = %(competition_id)s
+GROUP BY cp.user_id
 ORDER BY points DESC
 LIMIT %(threshold)s

--- a/smbbackend/sqlqueries/select-user-score-pollutant-savings.sql
+++ b/smbbackend/sqlqueries/select-user-score-pollutant-savings.sql
@@ -3,8 +3,9 @@ SELECT
 FROM tracks_segment AS s
   JOIN tracks_emission AS e ON (s.id = e.segment_id)
   JOIN tracks_track AS t ON (t.id = s.track_id)
-  JOIN profiles_smbuser AS u ON (u.id = t.owner_id)
+  JOIN prizes_competitionparticipant cp on t.owner_id = cp.user_id
 WHERE s.start_date >= %(start_date)s
   AND s.end_date <= %(end_date)s
-  AND u.id = %(user_id)s
+  AND cp.user_id = %(user_id)s
+  AND cp.registration_status = 'approved'
   AND t.is_valid = true

--- a/tests/unittests/test_processor_unit.py
+++ b/tests/unittests/test_processor_unit.py
@@ -8,7 +8,10 @@
 #
 #########################################################################
 
+import datetime as dt
+
 import pytest
+import pytz
 
 pytestmark = pytest.mark.unit
 
@@ -41,3 +44,188 @@ def test_validate_segment_duration(vehicle_type, duration, thresholds,
     else:
         with pytest.raises(exceptions.RecoverableError):
             processor.validate_segment_duration(info, thresholds)
+
+
+@pytest.mark.parametrize("raw_data, expected", [
+    (
+        (
+            "\n0,0,0,0,0,0,0,0,0,0,0,0,43.8400862704083,10.5083749143491,0,0,"
+            "0,1537193729,15,0,1536830986000,2,0"
+        ),
+        [
+            processor.PointData(
+                latitude=43.8400862704083,
+                longitude=10.5083749143491,
+                accuracy=0.0,
+                speed=15.0,
+                timestamp=dt.datetime(2018, 9, 13, 9, 29, 46, tzinfo=pytz.utc),
+                vehicle_type=VehicleType.bus,
+                session_id=1537193729,
+
+            )
+        ]
+    ),
+    pytest.param("", [], id="no data"),
+    pytest.param("dummy", [], id="only header"),
+    pytest.param(
+        (
+            "\n"
+            "0,0,0,0,0,0,0,0,0,0,0,0,43.8401082380725,10.5084723757338,0,0,"
+            "0,1537193729,15,0,1536830988728,2,0\n"
+            "0,0,0,0,0,0,0,0,0,0,0,0,43.8401521733766,10.5085820197916,0,0,0,"
+            "1537193729,15,0,1536830992079,2,0"
+        ),
+        [
+            processor.PointData(
+                latitude=43.8401082380725,
+                longitude=10.5084723757338,
+                accuracy=0.0,
+                speed=15.0,
+                timestamp=dt.datetime(
+                    2018, 9, 13, 9, 29, 48, 728000, tzinfo=pytz.utc),
+                vehicle_type=VehicleType.bus,
+                session_id=1537193729,
+            ),
+            processor.PointData(
+                latitude=43.8401521733766,
+                longitude=10.5085820197916,
+                accuracy=0.0,
+                speed=15.0,
+                timestamp=dt.datetime(
+                    2018, 9, 13, 9, 29, 52, 79000, tzinfo=pytz.utc),
+                vehicle_type=VehicleType.bus,
+                session_id=1537193729,
+            ),
+        ],
+        id="sorted inputs"
+    ),
+    pytest.param(
+        (
+                "\n"
+                "0,0,0,0,0,0,0,0,0,0,0,0,43.8401521733766,10.5085820197916,0,0,0,"
+                "1537193729,15,0,1536830992079,2,0\n"
+                "0,0,0,0,0,0,0,0,0,0,0,0,43.8401082380725,10.5084723757338,0,0,"
+                "0,1537193729,15,0,1536830988728,2,0\n"
+        ),
+        [
+            processor.PointData(
+                latitude=43.8401082380725,
+                longitude=10.5084723757338,
+                accuracy=0.0,
+                speed=15.0,
+                timestamp=dt.datetime(
+                    2018, 9, 13, 9, 29, 48, 728000, tzinfo=pytz.utc),
+                vehicle_type=VehicleType.bus,
+                session_id=1537193729,
+            ),
+            processor.PointData(
+                latitude=43.8401521733766,
+                longitude=10.5085820197916,
+                accuracy=0.0,
+                speed=15.0,
+                timestamp=dt.datetime(
+                    2018, 9, 13, 9, 29, 52, 79000, tzinfo=pytz.utc),
+                vehicle_type=VehicleType.bus,
+                session_id=1537193729,
+            ),
+        ],
+        id="non sorted inputs"
+    ),
+    pytest.param(
+        (
+            "\n"
+            "0,0,0,0,0,0,0,0,0,0,0,0,43.8401521733766,10.5085820197916,0,0,0,"
+            "1537193729,15,0,15368309920790000,2,0\n"
+        ),
+        [],
+        id="faulty line (timestamp out of range) is discarded"
+    ),
+    pytest.param(
+        (
+                "\n"
+                "0,0,0,0,0,0,0,0,0,0,0,0,100,10.5085820197916,0,0,0,"
+                "1537193729,15,0,1536830992079,1000,0\n"
+        ),
+        [],
+        id="faulty line (invalid vehicle type) is discarded"
+    ),
+    pytest.param(
+        (
+                "\n"
+                "0,0,0,0,0,0,0,0,0,0,0,0,100,10.5085820197916,0,0,0,"
+                "abcd,15,0,1536830992079,2,0\n"
+        ),
+        [],
+        id="faulty line (invalid session_id) is discarded"
+    ),
+
+])
+def test_parse_point_raw_data(raw_data, expected):
+    result = processor.parse_point_raw_data(raw_data)
+    for index, parsed_point in enumerate(result):
+        expected_point = expected[index]
+        assert parsed_point.latitude == expected_point.latitude
+        assert parsed_point.longitude == expected_point.longitude
+        assert parsed_point.accuracy == expected_point.accuracy
+        assert parsed_point.speed == expected_point.speed
+        assert parsed_point.timestamp == expected_point.timestamp
+        assert parsed_point.vehicle_type == expected_point.vehicle_type
+        assert parsed_point.session_id == expected_point.session_id
+
+
+@pytest.mark.parametrize("points", [
+    pytest.param(
+        [],
+        marks=pytest.mark.raises(exception=exceptions.NonRecoverableError),
+        id="Raises due to not enough points",
+    ),
+    pytest.param(
+        [
+            processor.PointData(
+                latitude=0,
+                longitude=0,
+                accuracy=0,
+                speed=0,
+                timestamp=dt.datetime(2018, 9, 13),
+                vehicle_type=VehicleType.bus,
+                session_id=1,
+            ),
+            processor.PointData(
+                latitude=0,
+                longitude=0,
+                accuracy=0,
+                speed=0,
+                timestamp=dt.datetime(2018, 9, 13),
+                vehicle_type=VehicleType.bus,
+                session_id=2,
+            ),
+        ],
+        marks=pytest.mark.raises(exception=exceptions.NonRecoverableError),
+        id="Raises due to multiple session ids",
+    ),
+    pytest.param(
+        [
+            processor.PointData(
+                latitude=0,
+                longitude=0,
+                accuracy=0,
+                speed=0,
+                timestamp=dt.datetime(2018, 9, 13),
+                vehicle_type=VehicleType.bus,
+                session_id=1,
+            ),
+            processor.PointData(
+                latitude=0,
+                longitude=0,
+                accuracy=0,
+                speed=0,
+                timestamp=dt.datetime(2018, 9, 13),
+                vehicle_type=VehicleType.bus,
+                session_id=1,
+            ),
+        ],
+        id="all good",
+    ),
+])
+def test_validate_points(points):
+    processor.validate_points(points)


### PR DESCRIPTION
This PR refactors the code and SQL queries that take care of calculating user scores and competition rankings in order to conform with the recent changes on the database.

These changes created the `prizes_competitionparticipant` table and also refactored some of the other tables' foreign keys. 

This PR's most relevant changes accomodate for the competition_participant by querying that table instead of the `prizes_competition` table now. This means that only users that are actually subscribed (and approved) in a competition are taken into account when scoring and ranking.