### PR TITLE
58 error when sending winner notifications

### DIFF
--- a/smbbackend/awshandlers.py
+++ b/smbbackend/awshandlers.py
@@ -320,11 +320,12 @@ def _setup_logging():
 
 def _notify_competition_winners(competition_results, db_cursor):
     for competition_info, winners in competition_results:
-        for winner in winners:
+        for index, winner in enumerate(winners):
+            competition_rank = index + 1
             user_id = winner["user"]
             user_uuid = utils.get_user_uuid(user_id, db_cursor)
             prize_names = calculateprizes.get_prize_names(
-                competition_info.id, winner["rank"], db_cursor)
+                competition_info.id, competition_rank, db_cursor)
             devices = get_user_active_devices(db_cursor, user_uuid)
             for prize_name in prize_names:
                 _send_notification(

--- a/smbbackend/awshandlers.py
+++ b/smbbackend/awshandlers.py
@@ -14,8 +14,7 @@ import json
 import logging
 import os
 import re
-from typing import List
-from typing import Tuple
+import typing
 
 from pyfcm import FCMNotification
 
@@ -151,7 +150,7 @@ def get_new_track_info(db_cursor, bucket_name, object_key, **kwargs):
 
 
 def ingest_track(db_cursor, bucket_name, object_key, owner_uuid,
-                 notify_completion=True, **kwargs) -> Tuple[int, bool]:
+                 notify_completion=True, **kwargs) -> typing.Tuple[int, bool]:
     try:
 
         raw_data = processor.get_data_from_s3(bucket_name, object_key)
@@ -296,7 +295,7 @@ def get_user_active_devices(db_cursor, user_uuid):
     return [row[0] for row in db_cursor.fetchall()]
 
 
-def _flatten_validation_errors(errors: List[List[dict]]):
+def _flatten_validation_errors(errors: typing.List[typing.List[typing.Dict]]):
     flattened_errors = ""
     for segment_errors in errors:
         for error in segment_errors:
@@ -318,7 +317,15 @@ def _setup_logging():
         logging.getLogger(log_name).propagate = False
 
 
-def _notify_competition_winners(competition_results, db_cursor):
+def _notify_competition_winners(
+        competition_results: typing.List[
+            typing.Tuple[
+                calculateprizes.CompetitionInfo,
+                typing.List[typing.Dict]
+            ]
+        ],
+        db_cursor
+):
     for competition_info, winners in competition_results:
         for index, winner in enumerate(winners):
             competition_rank = index + 1

--- a/smbbackend/calculateprizes.py
+++ b/smbbackend/calculateprizes.py
@@ -16,12 +16,10 @@ This module should be called periodically
 
 from collections import namedtuple
 from functools import partial
-from itertools import product
 import datetime as dt
 import json
 import logging
-from typing import List
-from typing import Tuple
+import typing
 
 import pytz
 
@@ -30,7 +28,6 @@ from ._constants import PrizeCriterium
 
 logger = logging.getLogger(__name__)
 
-LeaderBoardInfo = Tuple[PrizeCriterium, dict]
 
 CompetitionInfo = namedtuple("CompetitionInfo", [
     "id",
@@ -49,8 +46,12 @@ CompetitorInfo = namedtuple("CompetitorInfo", [
     "absolute_score"
 ])
 
+LeaderBoardInfo = typing.Tuple[PrizeCriterium, typing.List[CompetitorInfo]]
 
-def calculate_prizes(db_cursor) -> List[Tuple[CompetitionInfo, List[dict]]]:
+
+def calculate_prizes(
+        db_cursor
+) -> typing.List[typing.Tuple[CompetitionInfo, typing.List[dict]]]:
     """Calculate results for currently open competitions"""
     now = dt.datetime.now(pytz.utc)
     open_competitions = get_open_competitions(db_cursor)
@@ -82,7 +83,7 @@ def close_competition(competition, leaderboard, db_cursor):
     )
 
 
-def get_open_competitions(db_cursor) -> List[CompetitionInfo]:
+def get_open_competitions(db_cursor) -> typing.List[CompetitionInfo]:
     """Get information from the currently open competitions
 
     Open competitions are those whose start_date is lower than the current
@@ -98,7 +99,10 @@ def get_open_competitions(db_cursor) -> List[CompetitionInfo]:
     return [CompetitionInfo(*row) for row in db_cursor.fetchall()]
 
 
-def get_leaderboard(competition: CompetitionInfo, db_cursor) -> List[dict]:
+def get_leaderboard(
+        competition: CompetitionInfo,
+        db_cursor
+) -> typing.List[dict]:
     criteria_handlers = {
         PrizeCriterium.saved_so2: partial(get_emissions_ranking, "so2_saved"),
         PrizeCriterium.saved_co2: partial(get_emissions_ranking, "co2_saved"),
@@ -107,19 +111,77 @@ def get_leaderboard(competition: CompetitionInfo, db_cursor) -> List[dict]:
         PrizeCriterium.saved_pm10: partial(
             get_emissions_ranking, "pm10_saved"),
     }
-    criteria_leaderboards = []
+    criteria_leaderboards = {}
     threshold = len(competition.criteria) * competition.winner_threshold
     for criterium in competition.criteria:
         criterium_enumeration = PrizeCriterium(criterium)
         handler = criteria_handlers[criterium_enumeration]
-        ranking = handler(
+        criteria_leaderboards[criterium_enumeration.value] = handler(
             competition,
             threshold,
             db_cursor
         )
-        criteria_leaderboards.append((criterium_enumeration, ranking))
     logger.debug("criteria_leaderboards: {}".format(criteria_leaderboards))
     return consolidate_leaderboards(criteria_leaderboards)
+
+
+def consolidate_leaderboards(
+        leaderboards: typing.Dict[PrizeCriterium, typing.List[CompetitorInfo]]
+) -> typing.List[dict]:
+    """Return a sorted list with consolidated leaderboards
+
+    A user's leaderboards are consolidated into a single one by averaging the
+    points gotten in each leaderboard.
+
+    The final leaderboard is sorted in reverse order according to the final
+    score of each user. This means that the winner shall be the first in the
+    list.
+
+    """
+
+    summed_participant_scores = sum_participant_scores(leaderboards)
+    score_divisor = len(leaderboards)
+    final_leaderboard = []
+    for user_id, user_scores in summed_participant_scores.items():
+        final_leaderboard.append(
+            {
+                "user": user_id,
+                "points": user_scores["points"] / score_divisor,
+                "criteria_points": user_scores["boards"],
+            }
+        )
+    return sorted(final_leaderboard, key=lambda i: i["points"], reverse=True)
+
+
+def sum_participant_scores(
+        leaderboards: typing.Dict[
+            PrizeCriterium,
+            typing.List[CompetitorInfo]
+        ]
+) -> typing.Dict:
+    """Sum participant's scores across all criteria of a competition
+
+    A competition may use several criteria in order to attribute winners.
+    This function takes the leaderboards for each criterium and returns
+    an aggregated result per user.
+
+    """
+
+    consolidated_scores = {}
+    for criterium, leaderboard in leaderboards.items():
+        for competitor_info in leaderboard:
+            user_scores = consolidated_scores.setdefault(
+                competitor_info.user_id,
+                {
+                    "points": 0,
+                    "absolute_score": 0,
+                    "boards": {}
+                }
+            )
+            user_scores["points"] += competitor_info.points
+            user_scores["absolute_score"] += competitor_info.absolute_score
+            user_scores["boards"][criterium] = competitor_info.absolute_score
+    return consolidated_scores
 
 
 def get_user_score(competition: CompetitionInfo, user_id, db_cursor) -> dict:
@@ -143,14 +205,16 @@ def get_user_score(competition: CompetitionInfo, user_id, db_cursor) -> dict:
     return scores
 
 
-def select_competition_winners(competition: CompetitionInfo,
-                               leaderboard: List[dict]) -> List[dict]:
+def select_competition_winners(
+        competition: CompetitionInfo,
+        leaderboard: typing.List[dict]
+) -> typing.List[dict]:
     winner_threshold = competition.winner_threshold
     return leaderboard[:winner_threshold]
 
 
 def assign_competition_winners(
-        winners: List[dict],
+        winners: typing.List[dict],
         competition_id: int,
         db_cursor
 ):
@@ -187,58 +251,12 @@ def get_prize_names(competition_id: int, user_rank: int, db_cursor):
     return [record[0] for record in db_cursor.fetchall()]
 
 
-def consolidate_leaderboards(
-        leaderboards: List[LeaderBoardInfo]
-) -> List[dict]:
-    """Return a sorted list with consolidated leaderboards
-
-    A user's leaderboards are consolidated into a single one by averaging the
-    points gotten in each leaderboard.
-
-    The final leaderboard is sorted in reverse order according to the final
-    score of each user. This means that the winner shall be the first in the
-    list.
-
-    """
-
-    participants = get_unique_participants([b[1] for b in leaderboards])
-    null_competitor = CompetitorInfo(
-        points=0, user_id=None, absolute_score=0)
-    final_leaderboard = {}
-    for participant, board_info in product(participants, leaderboards):
-        criterium, board = board_info
-        final_leaderboard.setdefault(participant, {"points": 0, "boards": {}})
-        board_points = board.get(participant, null_competitor).points
-        board_score = board.get(participant, null_competitor).absolute_score
-        final_leaderboard[participant]["points"] += board_points
-        final_leaderboard[participant]["boards"][criterium.name] = board_score
-    score_divisor = sum(len(board) for board in leaderboards)
-    total = []
-    for user_id, data in final_leaderboard.items():
-        total.append(
-            {
-                "user": user_id,
-                "points": data["points"] / score_divisor,
-                "criteria_points": data["boards"]
-            }
-        )
-    return sorted(total, key=lambda i: i["points"], reverse=True)
-
-
-def get_unique_participants(leaderboards: List[dict]) -> List[str]:
-    all_participants = set()
-    for board in leaderboards:
-        for user_id in board.keys():
-            all_participants.add(user_id)
-    return list(all_participants)
-
-
 def get_emissions_ranking(
         pollutant: str,
         competition: CompetitionInfo,
         winner_threshold: int,
         db_cursor
-) -> dict:
+) -> typing.List[CompetitorInfo]:
     if competition.region_of_interest is not None:
         query_path = "select-pollutant-savings-leaderboard-with-roi.sql"
     else:
@@ -252,10 +270,9 @@ def get_emissions_ranking(
             "threshold": winner_threshold,
         }
     )
-    leaderboard = {}
+    leaderboard = []
     for row in db_cursor.fetchall():
-        info = CompetitorInfo(*row)
-        leaderboard[info.user_id] = info
+        leaderboard.append(CompetitorInfo(*row))
     else:
         if len(leaderboard) == 0:
             logger.debug("Leaderboard is empty")

--- a/smbbackend/calculateprizes.py
+++ b/smbbackend/calculateprizes.py
@@ -190,6 +190,17 @@ def get_prize_names(competition_id: int, user_rank: int, db_cursor):
 def consolidate_leaderboards(
         leaderboards: List[LeaderBoardInfo]
 ) -> List[dict]:
+    """Return a sorted list with consolidated leaderboards
+
+    A user's leaderboards are consolidated into a single one by averaging the
+    points gotten in each leaderboard.
+
+    The final leaderboard is sorted in reverse order according to the final
+    score of each user. This means that the winner shall be the first in the
+    list.
+
+    """
+
     participants = get_unique_participants([b[1] for b in leaderboards])
     null_competitor = CompetitorInfo(
         points=0, user_id=None, absolute_score=0)
@@ -211,7 +222,7 @@ def consolidate_leaderboards(
                 "criteria_points": data["boards"]
             }
         )
-    return sorted(total, key=lambda i: i["points"])
+    return sorted(total, key=lambda i: i["points"], reverse=True)
 
 
 def get_unique_participants(leaderboards: List[dict]) -> List[str]:

--- a/tests/unittests/test_calculateprizes.py
+++ b/tests/unittests/test_calculateprizes.py
@@ -1,0 +1,127 @@
+#########################################################################
+#
+# Copyright 2019, GeoSolutions Sas.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#########################################################################
+
+import pytest
+
+from smbbackend import calculateprizes
+from smbbackend._constants import PrizeCriterium
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "summed_participant_scores", [
+        pytest.param(
+            {
+                "fake_user1": {},
+            },
+        )
+    ]
+)
+def test_consolidate_leaderboards(summed_participant_scores):
+    result = calculateprizes.consolidate_leaderboards(criteria_boards)
+    expected = None
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "criteria_boards, expected",
+    [
+        pytest.param(
+            {
+                PrizeCriterium.saved_co2: [
+                    calculateprizes.CompetitorInfo(
+                        user_id="fake_user1",
+                        points=1,
+                        absolute_score=20
+                    ),
+                    calculateprizes.CompetitorInfo(
+                        user_id="fake_user2",
+                        points=0,
+                        absolute_score=0
+                    ),
+                ]
+            },
+            {
+                "fake_user1": {
+                    "points": 1,
+                    "absolute_score": 20,
+                    "boards": {
+                        PrizeCriterium.saved_co2: 20
+                    },
+                },
+                "fake_user2": {
+                    "points": 0,
+                    "absolute_score": 0,
+                    "boards": {
+                        PrizeCriterium.saved_co2: 0
+                    },
+                },
+            },
+            id="single_criterium"
+        ),
+        pytest.param(
+            {
+                PrizeCriterium.saved_co2: [
+                    calculateprizes.CompetitorInfo(
+                        user_id="fake_user1",
+                        points=1,
+                        absolute_score=20
+                    ),
+                    calculateprizes.CompetitorInfo(
+                        user_id="fake_user2",
+                        points=0,
+                        absolute_score=0
+                    ),
+                ],
+                PrizeCriterium.saved_so2: [
+                    calculateprizes.CompetitorInfo(
+                        user_id="fake_user1",
+                        points=3,
+                        absolute_score=30
+                    ),
+                    calculateprizes.CompetitorInfo(
+                        user_id="fake_user3",
+                        points=2,
+                        absolute_score=15
+                    ),
+                ]
+            },
+            {
+                "fake_user1": {
+                    "points": 4,
+                    "absolute_score": 50,
+                    "boards": {
+                        PrizeCriterium.saved_co2: 20,
+                        PrizeCriterium.saved_so2: 30,
+                    },
+                },
+                "fake_user2": {
+                    "points": 0,
+                    "absolute_score": 0,
+                    "boards": {
+                        PrizeCriterium.saved_co2: 0,
+                    },
+                },
+                "fake_user3": {
+                    "points": 2,
+                    "absolute_score": 15,
+                    "boards": {
+                        PrizeCriterium.saved_so2: 15
+                    },
+                },
+            },
+            id="two_criteria"
+        ),
+    ]
+)
+def test_sum_participant_scores(criteria_boards, expected):
+    result = calculateprizes.sum_participant_scores(criteria_boards)
+    assert result == expected


### PR DESCRIPTION
This PR refactors competition leaderboard calculations in order to

-  fix bug with possibly incorrect ranking - the `calculateprizes.get_emissions_ranking` function was previously returning a `dict`. This was problematic since the correctly sorted results which were gotten from the DB could end up with their ranking order altered (as dicts do not preserve ordering of their items). That function has been fixed and the winner ranking is now respected throughout the code

-  allow proper notification of competition winners (as reported originally with #58) - This was fixed by getting the user's competition rank by its position in the leaderboard, instead of relying on a non existing dictionary key 

-  make the `smbbackend.calculateprizes` module more readable

fixes #58